### PR TITLE
Use the npm version of the creditkey-js package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "bulma": "^0.9.0",
-    "creditkey-js": "file:../creditkey-js",
+    "creditkey-js": "^1.0.72",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3965,8 +3965,10 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-"creditkey-js@file:../creditkey-js":
+creditkey-js@^1.0.72:
   version "1.0.72"
+  resolved "https://registry.yarnpkg.com/creditkey-js/-/creditkey-js-1.0.72.tgz#3886cb2002e49e2af4202b432595b857f1131ccd"
+  integrity sha512-0wX01t2pdhsg3IZIX6ELW7yW6Y4ZZQlMrbgiH2A2Rp8Ad1wmcAerh9lTf7kvIedjADhCwgV/d5rm2xYaJ8Y+RQ==
   dependencies:
     bulma "^0.7.2"
     lodash "^4.17.15"


### PR DESCRIPTION
Doesn't seem like we want to have this be a local dep by default.