### PR TITLE
refactor to use address object for contact and reuse lib/load_checkout

### DIFF
--- a/src/components/BadButton.js
+++ b/src/components/BadButton.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { calcCharges } from '../lib/utils';
-import loadModal from '../lib/load_modal';
+import loadCheckout from '../lib/load_checkout';
 
 export default function BadButton(props) {
   return (
-    <button className="button is-medium is-fullwidth is-danger is-outlined" onClick={() => loadModal(props.config, props, calcCharges(props.cart))}>
+    <button className="button is-medium is-fullwidth is-danger is-outlined" onClick={() => loadCheckout(props.config, props, calcCharges(props.cart))}>
       <FontAwesomeIcon icon={props.icon} />&nbsp;<span>{props.label}</span>
     </button>
   );

--- a/src/components/Display.js
+++ b/src/components/Display.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { calcCharges, client } from '../lib/utils';
-import loadModal from '../lib/load_modal';
+import loadCheckout from '../lib/load_checkout';
 
 export default function Display(props) {
   const [display, setDisplay] = useState();
@@ -22,7 +22,7 @@ export default function Display(props) {
   return (
     <div 
       className="is-size-6 checkout" 
-      onClick={() => !props.conditions.apply && loadModal(props.conditions, props, charges)} 
+      onClick={() => !props.conditions.apply && loadCheckout(props.conditions, props, charges)} 
       dangerouslySetInnerHTML={ { __html: display } } />
   );
 }

--- a/src/components/store/CheckoutWithCreditKey.js
+++ b/src/components/store/CheckoutWithCreditKey.js
@@ -5,29 +5,19 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { client } from "../../lib/utils";
+import loadCheckout from '../../lib/load_checkout';
 
 export default function CheckoutWithCreditKey({ address, cartItems, charges }) {
-  const returnUrl = "http://localhost:3000/store/credit-key/success?id=%CKKEY%&";
-  const cancelUrl = "http://localhost:3000/store/credit-key/cancelled";
   const [loading, setLoading] = useState(false);
-  const remoteId = new Date().getTime();
 
   const begin = () => {
     setLoading(true);
 
-    client
-      .begin_checkout(
-        cartItems,
-        address,
-        address,
-        charges,
-        remoteId,
-        remoteId,
-        returnUrl,
-        cancelUrl,
-        "redirect"
-      )
-      .then(res => ck.checkout(res.checkout_url, 'redirect'));
+    return loadCheckout(
+      {}, 
+      { address: address, cart: cartItems, redirect: true }, 
+      charges, 
+    );
   };
 
   return (

--- a/src/components/store/pages/checkout/index.js
+++ b/src/components/store/pages/checkout/index.js
@@ -47,12 +47,10 @@ function cartItem(item, cart) {
 
 function CheckoutPage() {
   const { cart, cartProducts, subTotal, taxes, total } = useCart();
-  const [contactInfo, setContactInfo] = useState({
-    email: `support+${new Date().getTime()}@creditkey.com`,
-    firstName: "Credit",
-    lastName: "Key",
-  });
   const [address, setAddress] = useState({
+    first_name: 'Credit',
+    last_name: 'Key',
+    email: `support+${new Date().getTime()}@creditkey.com`,
     street: "10573 W Pico Blvd",
     suite: "",
     country: "United States",
@@ -105,8 +103,8 @@ function CheckoutPage() {
                 <div className="step__sections">
                   {step === "contact" && (
                     <ContactStep
-                      contactInfo={contactInfo}
-                      setContactInfo={setContactInfo}
+                      address={address}
+                      setAddress={setAddress}
                       setStep={setStep}
                     />
                   )}
@@ -119,7 +117,6 @@ function CheckoutPage() {
                   )}
                   {step === "payment" && (
                     <PaymentStep
-                      contactInfo={contactInfo}
                       address={address}
                       setStep={setStep}
                     />

--- a/src/components/store/pages/checkout/steps/contact.js
+++ b/src/components/store/pages/checkout/steps/contact.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function ContactStep({ contactInfo, setContactInfo, setStep }) {
+export default function ContactStep({ address, setAddress, setStep }) {
   return (
     <div className="section section--contact-information">
       <div className="section__header">
@@ -32,12 +32,12 @@ export default function ContactStep({ contactInfo, setContactInfo, setStep }) {
                 name="checkout[email]"
                 id="checkout_email"
                 onChange={(e) => {
-                  setContactInfo({
-                    ...contactInfo,
+                  setAddress({
+                    ...address,
                     email: e.target.value,
                   });
                 }}
-                value={contactInfo.email}
+                value={address.email}
               />
             </div>
           </div>
@@ -57,12 +57,12 @@ export default function ContactStep({ contactInfo, setContactInfo, setStep }) {
                 name="checkout[shipping_address][first_name]"
                 id="checkout_shipping_address_first_name"
                 onChange={(e) => {
-                  setContactInfo({
-                    ...contactInfo,
-                    firstName: e.target.value,
+                  setAddress({
+                    ...address,
+                    first_name: e.target.value,
                   });
                 }}
-                value={contactInfo.firstName}
+                value={address.first_name}
               />
             </div>
           </div>
@@ -83,12 +83,12 @@ export default function ContactStep({ contactInfo, setContactInfo, setStep }) {
                 name="checkout[shipping_address][last_name]"
                 id="checkout_shipping_address_last_name"
                 onChange={(e) => {
-                  setContactInfo({
-                    ...contactInfo,
-                    lastName: e.target.value,
+                  setAddress({
+                    ...address,
+                    last_name: e.target.value,
                   });
                 }}
-                value={contactInfo.lastName}
+                value={address.last_name}
               />
             </div>
           </div>

--- a/src/components/store/pages/checkout/steps/payment.js
+++ b/src/components/store/pages/checkout/steps/payment.js
@@ -5,14 +5,14 @@ import CheckoutWithCreditKey from "../../../CheckoutWithCreditKey";
 import { makePhoneNumber } from "../../../../../lib/utils";
 import useCart from "../../../../../hooks/cart";
 
-export default function PaymentStep({ address, contactInfo, setStep }) {
+export default function PaymentStep({ address, setStep }) {
   const { cartProducts, subTotal, total, taxes } = useCart();
   const [method, setMethod] = useState("creditkey");
   const ckAddress = new ck.Address(
-    contactInfo.firstName,
-    contactInfo.lastName,
+    address.first_name,
+    address.last_name,
     "Credit Key",
-    contactInfo.email,
+    address.email,
     address.street,
     address.suite,
     address.city,

--- a/src/lib/load_checkout.js
+++ b/src/lib/load_checkout.js
@@ -1,19 +1,22 @@
 import ck from "creditkey-js";
 import { client, addEmailTestingConditions } from "./utils";
 
-export default function LoadModal(conditions = {}, state, charges) {
+export default function LoadCheckout(conditions = {}, state, charges) {
   let date = new Date();
   const remoteId = date.getTime();
   const customerId = date.getTime();
   const returnUrl = "http://localhost:3000/store/credit-key/success?id=%CKKEY%&storeId=2";
   const cancelUrl = "http://localhost:3000/store/credit-key/cancelled";
 
+  let address;
+
   const email = addEmailTestingConditions(
     state.username,
     "creditkey.com",
     conditions
   );
-  const address = new ck.Address(
+
+  const defaultAddressData = new ck.Address(
     "Test",
     "User",
     "Test Company",
@@ -24,7 +27,9 @@ export default function LoadModal(conditions = {}, state, charges) {
     "CA",
     "11111",
     state.phone
-  );
+  )
+
+  state.address ? address = state.address : address = defaultAddressData;
 
   client
     .begin_checkout(


### PR DESCRIPTION
We rely on the SDK address object to set contact and address info for billing and shipping address.  I found have contactInfo broken out as a separate piece of state confusing.  Also, I want the dev page and the demo checkout to reuse as much behavior as possible, so refactored `load_modal` to `load_checkout` and updated the store checkout to use that.